### PR TITLE
fix: revert all group id to `app.revanced`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,7 @@ subprojects {
                 maven(MavenPublication) {
                     from project.components.java
 
-                    groupId = 'app.revanced'
+                    groupId = project.name != 'brut.j.util' ? 'app.revanced' : 'org.apktool'
                     artifactId = project.name
                     version = mavenVersion
 

--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,7 @@ subprojects {
                 maven(MavenPublication) {
                     from project.components.java
 
-                    groupId = project.name != 'brut.j.util' ? 'app.revanced' : 'org.apktool'
+                    groupId = project.name != 'brut.j.common' ? 'app.revanced' : 'org.apktool'
                     artifactId = project.name
                     version = mavenVersion
 

--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,7 @@ subprojects {
                 maven(MavenPublication) {
                     from project.components.java
 
-                    groupId = (project.name == 'apktool-lib' || project.name == 'brut.j.util') ? 'app.revanced' : 'org.apktool'
+                    groupId = 'app.revanced'
                     artifactId = project.name
                     version = mavenVersion
 


### PR DESCRIPTION
There is a problem of using the upstream `org.apktool:brut.j.dir` because it depend on `org.apktool:brut.j.util` while our `app.revanced:apktool-lib` use `app.revanced:brut.j.util`. That bring back 'duplicate class issue'. I suggest publishing all 3 packages `brut.j.dir`, '`brut.j.common` and `brut.j.util` to prevent future issue.